### PR TITLE
Support Docker for Mac Beta; post_build hook

### DIFF
--- a/flyingcloud/base.py
+++ b/flyingcloud/base.py
@@ -169,6 +169,10 @@ class DockerBuildLayer(object):
         """Override if you need special handling"""
         pass
 
+    def post_build(self, namespace, target_container_name, salt_dir):
+        """Override if you need special handling"""
+        pass
+
     def build(self, namespace):
         salt_dir = os.path.abspath(os.path.join(namespace.salt_dir, self.layer_name))
 
@@ -261,6 +265,8 @@ class DockerBuildLayer(object):
                 "Finished Salting: duration=%d:%02d minutes", duration // 60, duration % 60)
             if self.salt_error(salt_output):
                 raise ExecError("salt_highstate failed.")
+
+            self.post_build(namespace, target_container_name, salt_dir)
 
             result = self.docker_commit(namespace, target_container_name, result_image_name)
             namespace.logger.info("Committed: %r", result)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='flyingcloud',
-    version='0.3.1',
+    version='0.3.2',
     description='Build Docker images using SaltStack',
     author='MetaBrite, Inc.',
     author_email='flyingcloud-admin@metabrite.com',


### PR DESCRIPTION
- On Mac, we assume by default that Docker Machine is being used. If you're using [Docker for Mac Beta](https://blog.docker.com/2016/03/docker-for-mac-windows-beta/), then add the `-m` (`--no-use-docker-machine`) flag to all uses of `flyingcloud`
- Add a `post_build` hook. You can implement this in your `layer.py` to perform operations after Salting but before the layer is committed.
