### PR TITLE
Fix/salt pip version problem in demo

### DIFF
--- a/examples/flask-web-app/DEMO.md
+++ b/examples/flask-web-app/DEMO.md
@@ -3,8 +3,22 @@
 # Preparation
 * Before the demo:
     * clean out all Docker containers and images, except Phusion
-    * Rebuild: `flyingcloud sysbase; flyingcloud pybase; flyingcloud opencv; flyingcloud app`
-
+    * Rebuild:
+        ```bash
+  flyingcloud --no-push --no-pull sysbase
+  flyingcloud --no-push --no-pull pybase
+  flyingcloud --no-push --no-pull opencv
+  flyingcloud --no-push --no-pull opencv
+  flyingcloud --no-push --no-pull app`
+        ```
+    * If using the Docker for Mac beta:
+        ```bash
+    flyingcloud --no-use-docker-machine --no-push --no-pull sysbase
+    flyingcloud --no-use-docker-machine --no-push --no-pull pybase
+    flyingcloud --no-use-docker-machine --no-push --no-pull opencv
+    flyingcloud --no-use-docker-machine --no-push --no-pull opencv
+    flyingcloud --no-use-docker-machine --no-push --no-pull app
+        ```
 
 # Demo steps
 

--- a/examples/flask-web-app/DEMO.md
+++ b/examples/flask-web-app/DEMO.md
@@ -11,7 +11,7 @@
   flyingcloud --no-push --no-pull opencv
   flyingcloud --no-push --no-pull app`
         ```
-    * If using the Docker for Mac beta:
+    * If using the Docker Mac beta:
         ```bash
     flyingcloud --no-use-docker-machine --no-push --no-pull sysbase
     flyingcloud --no-use-docker-machine --no-push --no-pull pybase
@@ -22,7 +22,7 @@
 
 # Demo steps
 
-* Demo the web app
+* Demo the web app (you will need to add `--no-use-docker-machine` if you are using the Docker Mac beta.)
     * `flyingcloud --run app`
 * use web browser to go to http://localhost:8080
 * Run tests with `flyingcloud --run testrunner`

--- a/examples/flask-web-app/salt/pybase/python27-update.sls
+++ b/examples/flask-web-app/salt/pybase/python27-update.sls
@@ -25,7 +25,7 @@ python2.7-update:
 # needed to get the latest pip
 python-pip-bootstrap:
   cmd.run:
-    - name: curl https://bootstrap.pypa.io/get-pip.py | python
+    - name: curl https://bootstrap.pypa.io/get-pip.py | python && pip install pip==8.1.1
     - reload_modules: true
 
 python-virtualenv:


### PR DESCRIPTION
- Fixes demo won't build problem (caused by [issue saltstack/salt#33163](https://github.com/saltstack/salt/issues/33163) )
- Adds documentation to help people in the Docker Mac Beta build the demo
