### PR TITLE
docker tags, --commit-failed-builds, prefer Docker for Mac/Windows

### DIFF
--- a/flyingcloud/base.py
+++ b/flyingcloud/base.py
@@ -726,7 +726,7 @@ class DockerBuildLayer(object):
         defaults.setdefault('password', os.environ.get(self.PASSWORD_ENV_VAR))
         defaults.setdefault('email', os.environ.get(self.EMAIL_ENV_VAR))
 
-        defaults.setdefault('use_docker_machine', True)
+        defaults.setdefault('use_docker_machine', False)  # Docker for Mac/Windows preferred
         defaults.setdefault('docker_machine_name',
                             os.environ.get('DOCKER_MACHINE_NAME', 'default'))
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='flyingcloud',
-    version='0.3.5',
+    version='0.3.6',
     description='Build Docker images using SaltStack',
     author='MetaBrite, Inc.',
     author_email='flyingcloud-admin@metabrite.com',


### PR DESCRIPTION
- 0.3.6 release 
- Update `docker_tags.json` on every successful push. Trying to reverse-engineer `latest` is error-prone.
- `--commit-failed-builds` commits a failed build. Will also push to repository, if configured. Useful for postmortem debugging
- Docker for Mac/Windows is now in public beta. Prefer that to Docker Machine.
