### PR TITLE
Fix/wrong layer import

### DIFF
--- a/flyingcloud/base.py
+++ b/flyingcloud/base.py
@@ -772,7 +772,6 @@ class DockerBuildLayer(object):
         defaults.setdefault(
             'timestamp',
             datetime.datetime.utcnow().strftime(defaults['timestamp_format']))
-        defaults.setdefault('layer_inst', self)
         defaults.setdefault('operation', 'build')
 
         defaults.setdefault('pull_layer', True)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='flyingcloud',
-    version='0.3.17',
+    version='0.3.18',
     description='Build Docker images using SaltStack',
     author='MetaBrite, Inc.',
     author_email='flyingcloud-admin@metabrite.com',


### PR DESCRIPTION
This was due to a bug in [argparse](https://bugs.python.org/issue9351)'s
handling of `set_defaults` in subparsers that was fixed in
[Python 2.7.10](https://www.python.org/downloads/release/python-2710/).

The FlyingCloud fix is to not set a default value for `layer_inst`
in the parent parser. It was unnecessary.